### PR TITLE
Dev/relative volume paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 app/config/*
 db/config/*
 db/data/*
+vol/app/config
+vol/bin/unifi-controller

--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ You COULD just clone this repo, but lets pretend you didn't and you just want to
 mkdir -p app/config
 mkdir -p db/data
 mkdir -p db/config
+mkdir -p init
 ```
 
-Copy the `docker-compose.yml` from this repo into `./` and copy `db/init-mongo.js` from the repo into `db/init-mongo.js`.
+Copy the `docker-compose.yml` from this repo into `./` and copy `init/init-mongo.js` from the repo into `init/init-mongo.js`.
 
 Your cwd should have folders/files like:
 
@@ -61,7 +62,8 @@ app/
 └── config/
 db/
 ├── config/
-├── data/
+└── data/
+init/
 └── init-mongo.js
 docker-compose.yml
 ```
@@ -73,7 +75,7 @@ You need to understand docker to make sense of all this, but short version if yo
 NOTE: I run this in the foreground so I can see things happening, if you want it in background add `-d`
 
 ```
-docker compose up
+docker compose up 
 ```
 
 Eventually output should hit a pause with a line like:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - MEM_LIMIT=1024 #optional
       - MEM_STARTUP=1024 #optional
     volumes:
-      - /home/joep/bin/unifi-controller/app/config:/config
+      - ./vol/app/config:/config
     networks:
       - unifi-network
     ports:
@@ -24,7 +24,7 @@ services:
       - 3478:3478/udp
       - 10001:10001/udp
       - 8080:8080
-      - 1900:1900/udp #optional
+     # - 1900:1900/udp #optional
       - 8843:8843 #optional
       - 8880:8880 #optional
       - 6789:6789 #optional
@@ -38,9 +38,9 @@ services:
     ports:
       - 27017:27017
     volumes:
-      - /home/joep/bin/unifi-controller/db/data:/data/db
-      - /home/joep/bin/unifi-controller/db/config:/data/configdb
-      - /home/joep/bin/unifi-controller/db/init-mongo.js:/docker-entrypoint-initdb.d/init-mongo.js:ro
+      - ./vol/bin/unifi-controller/db/data:/data/db
+      - ./vol/bin/unifi-controller/db/config:/data/configdb
+      - ./vol/init:/docker-entrypoint-initdb.d:ro
     restart: unless-stopped
 networks:
   unifi-network:

--- a/vol/init/init-mongo.js
+++ b/vol/init/init-mongo.js
@@ -1,0 +1,2 @@
+db.getSiblingDB("unifi").createUser({user: "unifi", pwd: "unifi", roles: [{role: "readWrite", db: "unifi"}]});
+db.getSiblingDB("unifi_stat").createUser({user: "unifi", pwd: "unifi", roles: [{role: "readWrite", db: "unifi_stat"}]});


### PR DESCRIPTION
I changed the volume paths to use relative paths from where this repo is checked out. Also, the mongodb init script was moved out of the db folder and into a new init folder.

I can get it to work if I first start the unifi-db container with the following command:
     docker compose up unifi-db

After it is up and running, I can go ahead and start the application in another terminal with
    docker compose up unifi-network-application

If I start it with docker compose up from scratch, the unifi-network-application crashes because it can't connect to the unifi-db, as it doesn't seem to be up and running just yet.

Anyway, this pull request should solve issue #1 